### PR TITLE
fixes for perl v5.36

### DIFF
--- a/modules/Collection.pm
+++ b/modules/Collection.pm
@@ -200,7 +200,7 @@ sub load{
 
         #print Dumper(%data);
 
-        push $self->{'records'}, {%data};
+        push @{ $self->{'records'} }, {%data};
 
         if ( $self->{'max_record_id'} < $data{'display_id'}){
             $self->{'max_record_id'} = $data{'display_id'};
@@ -576,7 +576,7 @@ sub updateRecord{
     }
 
     my $detail;
-    foreach my $f (sort keys $fields){
+    foreach my $f (sort keys %$fields){
         $detail.="$f>$fields->{$f} * ";
     }
 
@@ -663,7 +663,7 @@ sub matchRecords{
         my $match = 0;
         my $notmatch = 0;
 
-        foreach my $f (keys $fields){
+        foreach my $f (keys %$fields){
             #print "F is $f, rec is ".$rec->{$f}." fields is ".$fields->{$f}."\n";
             
             if ($rec->{$f} eq $fields->{$f}){

--- a/modules/CommandHandler.pm
+++ b/modules/CommandHandler.pm
@@ -347,7 +347,7 @@ sub doPluginBotStart{
     $self->{UserAuthObj} = $self->UserAuth->new($self->{BotDatabaseFile}, 
              UA_INTERNAL, UA_INTERNAL, $self->{sql_pragma_synchronous});
 
-    foreach my $plugin_name (keys $self->{plugin_info}){
+    foreach my $plugin_name (keys %{$self->{plugin_info}}){
         print "==> Init $plugin_name\n";
         my $p = $self->{plugin_info}->{$plugin_name}->{package}->new(
             $self->{plugin_info}->{$plugin_name}->{init_options}, $self->{UserAuthObj}
@@ -440,7 +440,7 @@ sub Execute {
 
     }elsif ($self->{command} eq '_CH_NEXT_msg_' && $self->{origin} eq 'internal'){
 
-        my $ret = shift ($self->{return_messages});
+        my $ret = shift (@{$self->{return_messages}});
 
         if (@{$self->{return_messages}} ){
             $ret->{reentry_command} = '_CH_NEXT_msg_';
@@ -485,7 +485,7 @@ sub Execute {
         my $out = "";
 
         if ($self->{SpeedTraceLevel} > 1){
-            foreach my $k (sort keys $self->{run_stats}){
+            foreach my $k (sort keys %{$self->{run_stats}}){
                 next if ($k eq 'CH');
                 my $total_time = sprintf("%.3f", $self->{run_stats}->{$k}->{end} - $self->{run_stats}->{$k}->{start});
                 $out.= "$k: $total_time \t ";
@@ -549,7 +549,7 @@ sub handleEvent{
     ## look for plugin matches to regexes & irc_events. Only call each once, 
     ##  even if multiple matches.
 
-    foreach my $k (keys $self->{plugin_info}){
+    foreach my $k (keys %{$self->{plugin_info}}){
 
         my %matched_plugins;
 
@@ -684,7 +684,7 @@ sub isCommand{
     my $self = shift;
     my $pcmd = shift;
 
-    foreach my $k (keys $self->{plugin_info}){
+    foreach my $k (keys %{$self->{plugin_info}}){
         foreach my $cmd (@{$self->{plugin_info}->{$k}->{commands}}){
             if ($cmd eq $pcmd){
                 return 1;
@@ -726,7 +726,7 @@ sub handleCommand{
     # regular command match, only if not already matched on Plugin.command notation.
     my @matches;
     if (!$self->{match}){
-        foreach my $k (keys $self->{plugin_info}){
+        foreach my $k (keys %{$self->{plugin_info}}){
             foreach my $cmd (@{$self->{plugin_info}->{$k}->{commands}}){
                 if ($cmd eq $self->{command}){
                     push @matches, $self->{plugin_info}->{$k};

--- a/modules/EventTimer.pm
+++ b/modules/EventTimer.pm
@@ -88,11 +88,11 @@ sub tick{
     ## Handle Events
 
     if ($self->{events}){
-        foreach my $k (sort keys $self->{events}){
+        foreach my $k (sort keys %{$self->{events}}){
             #print " " . ($k - $now) . " ";
         }
 
-        foreach my $k (keys $self->{events}){
+        foreach my $k (keys %{$self->{events}}){
             if ($k <= $now){
                 $self->processEvent($k);
                 $hasJobs = 1;

--- a/modules/PluginBaseClass.pm
+++ b/modules/PluginBaseClass.pm
@@ -600,7 +600,7 @@ sub numFlags{
     my $self = shift;
 
     if ($self->{FLAGS}){
-        my $c = keys ($self->{FLAGS});
+        my $c = keys (%{$self->{FLAGS}});
         $c = $c / 2;
         return $c;
     }else{
@@ -886,7 +886,7 @@ sub botCan{
         return 0;
     }
 
-    foreach my $k (keys $self->{BotPluginInfo}){
+    foreach my $k (keys %{$self->{BotPluginInfo}}){
         foreach my $cmd (@{$self->{BotPluginInfo}->{$k}->{commands}}){
             if ($cmd eq $pcmd){
                 return 1;

--- a/modules/Utilities.pm
+++ b/modules/Utilities.pm
@@ -147,7 +147,7 @@ sub parseFlags{
     $new_options=~s/ +$//;
     $new_options=~s/_BITEME_PARSEWORDS_/'/g;
     if ($FLAGS){
-        foreach my $flag (keys $FLAGS){
+        foreach my $flag (keys %$FLAGS){
             $FLAGS->{$flag}=~s/_BITEME_PARSEWORDS_/'/gis;
             $FLAGS->{$flag}=~s/^"(.+?)"$/$1/;
             #print "Flag is now $FLAGS->{$flag}\n";

--- a/plugins/Is.pm
+++ b/plugins/Is.pm
@@ -201,7 +201,7 @@ sub getOutput {
                 }
 
                 $ret = "I know $stats->{total_records} things.  ";
-                foreach my $k (keys $stats){
+                foreach my $k (keys %$stats){
                     next if $k eq 'total_records';
                     $ret.="$k ($stats->{$k}) ";
                 }  

--- a/plugins/TextUtils.pm
+++ b/plugins/TextUtils.pm
@@ -101,7 +101,7 @@ sub getOutput {
 
     if ($cmd eq 'listcolors'){
         my $bullet = "";
-        foreach (sort { ($colors->{$a} cmp $colors->{$b}) } keys $colors){
+        foreach (sort { ($colors->{$a} cmp $colors->{$b}) } keys %$colors){
             $output.= $bullet . $colors->{$_} . "$_"."\x0f" ;
             $bullet = " " . $self->BULLET ." ";
         }

--- a/plugins_sys/Admin.pm
+++ b/plugins_sys/Admin.pm
@@ -591,7 +591,7 @@ sub getOutput {
         ## list plugins - default action
         ##
 
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             if (@{$plugins->{$k}->{permissions}}){
                 my $found = 0;
                 no warnings;

--- a/plugins_sys/Help.pm
+++ b/plugins_sys/Help.pm
@@ -45,7 +45,7 @@ sub getOutput {
 
     if ($cmd eq 'plugins'){
         $output = "My Plugins:";
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             $output.=" $k";
         }
         return $output;
@@ -63,13 +63,13 @@ sub getOutput {
 
         $html.="<b>Enabled Plugins</b><br>";
         $html.="<ul>";
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             $html.="<li><a href=\"#$k\">$k</a></li>";
         }
         $html.="</ul>";
         $html.="<p>&nbsp;</p>";
 
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             $html.="<a name=\"$k\"></a>";
             $html.="\n<p><b>$k</b>:\n";
 
@@ -93,7 +93,7 @@ sub getOutput {
             
 
             $html.="<ul>";
-            foreach my $h (sort keys $o->{HELP}){
+            foreach my $h (sort keys %{$o->{HELP}}){
                 my $key = $h;
                 my $text = $o->{HELP}->{$h};
                 next if ($key eq '[plugin_description]');
@@ -114,7 +114,7 @@ sub getOutput {
 
     if ($cmd eq 'allcommands'){
         my @commands;
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             foreach my $command (@{$plugins->{$k}->{commands}}){
                 if (!$self->hasFlag("all")){
                     #print "ask for $k - $command\n";
@@ -146,7 +146,7 @@ sub getOutput {
 
     if ($cmd eq 'allregex'){
         my @exp;
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             foreach my $regex (@{$plugins->{$k}->{preg_matches}}){
                 push @exp, "$k: $regex";
             }
@@ -164,7 +164,7 @@ sub getOutput {
         my $ret = BOLD."$size regex matches: ".NORMAL . $list;
 
         my @exc;
-        foreach my $k (sort keys $plugins){
+        foreach my $k (sort keys %$plugins){
             foreach my $regex (@{$plugins->{$k}->{preg_excludes}}){
                 push @exc, "$k: $regex";
             }
@@ -281,7 +281,7 @@ sub getOutput {
         if (!$package){
             my @found;
             #my $cmd = $testpackage;  #just to make this clearer # not
-            foreach my $entry (keys $plugins){
+            foreach my $entry (keys %$plugins){
                 foreach my $cmd (@{$plugins->{$entry}->{commands}}){
                     if ($cmd eq $testpackage){
                         ## found it. let's make sure it's the only one.

--- a/rocksbot.pl
+++ b/rocksbot.pl
@@ -22,6 +22,7 @@
 
 use strict;
 use warnings;
+use lib '.';
 use modules::RocksBot;
 use constant RocksBot => 'modules::RocksBot';
 use Cwd qw(abs_path getcwd);


### PR DESCRIPTION
Fixes for perl v5.36

Example:
ch1:ERR: Experimental keys on scalar is now forbidden at plugins/Is.pm line 204.
ch1:ERR: Type of arg 1 to keys must be hash or array (not private variable) at plugins/Is.pm line 204, near "$stats)"

All usages of push/keys/etc on scalar have been fixed to point to hash or array.

There might be more runtime errors lurking, I haven't audited/tested all features.

This was tested on chromeOS in a debian VM.